### PR TITLE
Fix Notes Link in 01-23-agenda.md

### DIFF
--- a/2025/telcons/01-23-agenda.md
+++ b/2025/telcons/01-23-agenda.md
@@ -15,7 +15,7 @@ This call will take place at a Europe-friendly time: noon in Boston (EDT), which
 | 17:00 (5 PM) | Thu | London        |
 | 18:00 (6 PM) | Thu | Brussels      |
 
-We use [this Google Doc](https://docs.google.com/document/d/1jxqW4kvGdclIWsOlWMXWLGpwu1wOorST2Ol6vJKAjDE/edit) for taking minutes.
+We use [this Google Doc](https://docs.google.com/document/d/1qt6xBGLXC2z1YFZXGeRlcWedF648jY16wJiwwgjfbdA/edit) for taking minutes.
 
 ### Join Meeting
 


### PR DESCRIPTION
We had to use a new doc for the moment.